### PR TITLE
(fix) ChatCompletionChunk not matching JSON response

### DIFF
--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -132,6 +132,7 @@ impl ChatApi {
                     message: format!("LinesCodec error: {}", e),
                     metadata: None,
                 })?;
+
                 if line.trim().is_empty() {
                     continue;
                 }
@@ -140,9 +141,13 @@ impl ChatApi {
                     if data_part == "[DONE]" {
                         break;
                     }
+
                     match serde_json::from_str::<ChatCompletionChunk>(data_part) {
                         Ok(chunk) => yield chunk,
-                        Err(_err) => continue,
+                        Err(err) => {
+                            tracing::error!("Stream error: {}", err); 
+                            continue;
+                        },
                     }
                 } else if line.starts_with(":") {
                     // Ignore SSE comment lines.

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -105,11 +105,17 @@ impl ChatApi {
             })?;
             req_body["stream"] = serde_json::Value::Bool(true);
 
-            // Issue the POST request with error-for-status checking.
-            let response = client
+            tracing::debug!("req_body: {:?}", req_body);
+
+            let req_builder = client
                 .post(url)
                 .headers(config.build_headers()?)
-                .json(&req_body)
+                .json(&req_body);
+
+            tracing::debug!("req_builder: {:?}", req_builder);
+
+            // Issue the POST request with error-for-status checking.
+            let response = req_builder
                 .send()
                 .await?
                 .error_for_status()

--- a/src/client.rs
+++ b/src/client.rs
@@ -245,11 +245,15 @@ impl OpenRouterClient<Ready> {
         for choice in &response.choices {
             if let Some(tool_calls) = &choice.message.tool_calls {
                 for tc in tool_calls {
-                    if tc.kind != "function" {
-                        return Err(Error::SchemaValidationError(format!(
-                            "Invalid tool call kind: {}. Expected 'function'",
-                            tc.kind
-                        )));
+                    // When streaming, the first chunk only will contain "function".
+                    // See: https://platform.openai.com/docs/guides/function-calling?api-mode=chat#streaming
+                    if let Some(kind) = &tc.kind {
+                        if kind != "function" {
+                            return Err(Error::SchemaValidationError(format!(
+                                "Invalid tool call kind: {}. Expected 'function'",
+                                kind
+                            )));
+                        }
                     }
                 }
             }

--- a/src/models/chat.rs
+++ b/src/models/chat.rs
@@ -34,9 +34,10 @@ impl From<ChatMessage> for crate::types::chat::Message {
         };
         Self {
             role: role_str,
-            content: chat_msg.content,
+            content: Some(chat_msg.content),
             name: None,
             tool_calls: None,
+            tool_call_id: None,
         }
     }
 }

--- a/src/models/tool.rs
+++ b/src/models/tool.rs
@@ -49,7 +49,7 @@ pub enum Tool {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FunctionCall {
     /// The name of the function to call.
-    pub name: String,
+    pub name: Option<String>,
     /// A JSON string representing the arguments for the function call.
     pub arguments: String,
 }
@@ -61,10 +61,12 @@ pub struct FunctionCall {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
     /// A unique identifier for the tool call.
-    pub id: String,
-    /// The type of call. It must be "function" for function calls.
+    pub id: Option<String>,
+    /// The index of the tool call in the list of tool calls
+    pub index: u32,
+    /// The type of call. When streaming, the first chunk only will contain "function".
     #[serde(rename = "type")]
-    pub kind: String,
+    pub kind: Option<String>,
     /// The details of the function call, including its function name and arguments.
     #[serde(rename = "function")]
     pub function_call: FunctionCall,

--- a/src/models/tool.rs
+++ b/src/models/tool.rs
@@ -63,7 +63,8 @@ pub struct ToolCall {
     /// A unique identifier for the tool call.
     pub id: Option<String>,
     /// The index of the tool call in the list of tool calls
-    pub index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<u32>,
     /// The type of call. When streaming, the first chunk only will contain "function".
     #[serde(rename = "type")]
     pub kind: Option<String>,

--- a/src/tests/integration_tests.rs
+++ b/src/tests/integration_tests.rs
@@ -46,7 +46,7 @@ mod integration_tests {
             model: "openai/gpt-4o".to_string(),
             messages: vec![Message {
                 role: "user".to_string(),
-                content: "What is a phantom type in Rust?".to_string(),
+                content: Some("What is a phantom type in Rust?".to_string()),
                 name: None,
                 tool_calls: None,
             }],

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -51,7 +51,8 @@ pub struct ChatCompletionRequest {
 
 #[derive(Debug, Serialize)]
 pub struct ResponseFormat {
-    pub r#type: String 
+    #[serde(rename = "type")]
+    pub format_type: String 
 }
 
 /// A choice returned by the chat API.

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -1,5 +1,6 @@
 use crate::models::tool::ToolCall;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Defines the role of a chat message (user, assistant, or system).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,7 +53,15 @@ pub struct ChatCompletionRequest {
 #[derive(Debug, Serialize)]
 pub struct ResponseFormat {
     #[serde(rename = "type")]
-    pub format_type: String 
+    pub format_type: String,
+    pub json_schema: Option<JsonSchema>
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonSchema {
+    pub name: String,
+    pub strict: bool,
+    pub schema: Value
 }
 
 /// A choice returned by the chat API.

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -58,6 +58,20 @@ pub struct Choice {
     pub native_finish_reason: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ChoiceStream {
+    pub index: u32,
+    pub delta: StreamDelta,
+    pub finish_reason: Option<String>,
+    pub native_finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamDelta {
+    pub role: String,
+    pub content: String,
+}
+
 /// Usage data returned from the API.
 #[derive(Debug, Deserialize)]
 pub struct Usage {
@@ -80,5 +94,6 @@ pub struct ChatCompletionResponse {
 #[derive(Debug, Deserialize)]
 pub struct ChatCompletionChunk {
     pub id: String,
-    pub choices: Vec<Choice>,
+    pub choices: Vec<ChoiceStream>,
+    pub usage: Option<Usage>,
 }

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -34,7 +34,7 @@ pub struct ChatCompletionRequest {
     pub stream: Option<bool>,
     /// (Optional) Stub for response_format.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_format: Option<String>,
+    pub response_format: Option<ResponseFormat>,
     /// (Optional) Tool calling field. Now uses our production‑ready tool types.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<crate::models::tool::Tool>>,
@@ -47,6 +47,11 @@ pub struct ChatCompletionRequest {
     /// (Optional) Message transforms.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transforms: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResponseFormat {
+    r#type: String 
 }
 
 /// A choice returned by the chat API.

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -51,7 +51,7 @@ pub struct ChatCompletionRequest {
 
 #[derive(Debug, Serialize)]
 pub struct ResponseFormat {
-    r#type: String 
+    pub r#type: String 
 }
 
 /// A choice returned by the chat API.

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -15,12 +15,16 @@ pub enum ChatRole {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: String,
-    pub content: String,
+
+    pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     // Optionally include tool_calls when the assistant message contains a tool call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 /// Chat completion request matching the OpenRouter API schema.

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -54,6 +54,7 @@ pub struct ChatCompletionRequest {
 pub struct ResponseFormat {
     #[serde(rename = "type")]
     pub format_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub json_schema: Option<JsonSchema>
 }
 

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -84,8 +84,9 @@ pub struct ChoiceStream {
 
 #[derive(Debug, Deserialize)]
 pub struct StreamDelta {
-    pub role: String,
-    pub content: String,
+    pub role: Option<String>,
+    pub content: Option<String>,
+    pub tool_calls: Option<Vec<ToolCall>>,
 }
 
 /// Usage data returned from the API.


### PR DESCRIPTION
Hey there. Thanks for the crate it's really nice to work with! 

I ran into an issue today however working with streaming. It looks like the response from OpenRouter does not contain a "message" object like the normal "Choice" object does. I created a new struct called ChoiceStream which matches the response from OpenRouter.

Furthermore, I added Usage as an optional field because the usage does get returned on the last message from OpenRouter. This is useful consumers of the library to be able to get token usage even for streamed endpoints. 

I also added a `tracing::error!()` to the error branch of the match statement. I thought this might be helpful again for users of the crate. I had to fork the crate in order to debug for myself what was going wrong. 