### PR TITLE
(fix) `provider` field in ChatCompletionRequest was string instead of struct

### DIFF
--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -40,7 +40,7 @@ pub struct ChatCompletionRequest {
     pub tools: Option<Vec<crate::models::tool::Tool>>,
     /// (Optional) Stub for provider preferences.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider: Option<String>,
+    pub provider: Option<super::ProviderPreferences>,
     /// (Optional) Fallback models.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub models: Option<Vec<String>>,


### PR DESCRIPTION
The type of the `provider` field in `ChatCompletionRequest` was `Option<String>` which causes this error when a _Provider Preferences_ is supplied:
```json
{
  "error": {
    "message": [
      {
        "code": "invalid_type",
        "expected": "object",
        "received": "string",
        "path": [
          "provider"
        ],
        "message": "Expected object, received string"
      }
    ],
    "code": 400
  },
  "user_id": "user_2uUDKpa3G9ObAWxndozny2puern"
}
```

To fix this, I replaced its type by `Option<super::ProviderPreferences>`.