### PR TITLE
load_api_key_from_env also loads OPENROUTER_API_KEY from .env 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["openrouter", "ai", "api-client"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
-dotenv = "0.15"
+dotenvy = "0.15.7"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["openrouter", "ai", "api-client"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
+dotenv = "0.15"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/tests/integration_tests.rs
+++ b/src/tests/integration_tests.rs
@@ -20,8 +20,9 @@ mod integration_tests {
     use crate::models::tool::{FunctionCall, FunctionDescription, Tool, ToolCall};
     use crate::types::chat::{ChatCompletionRequest, ChatCompletionResponse, Message};
     use serde_json::{json, Value};
-    use std::env;
     use url::Url;
+
+    use crate::utils::auth::load_api_key_from_env;
 
     // Helper function to deserialize a ChatCompletionResponse from JSON.
     fn deserialize_chat_response(json_str: &str) -> ChatCompletionResponse {
@@ -31,8 +32,7 @@ mod integration_tests {
     #[tokio::test]
     async fn test_basic_chat_completion() -> Result<(), Box<dyn std::error::Error>> {
         // Read the API key from the environment.
-        let api_key = env::var("OPENROUTER_API_KEY")
-            .map_err(|e| format!("OPENROUTER_API_KEY must be set in the environment: {}", e))?;
+        let api_key = load_api_key_from_env()?;
 
         // Build the client: Unconfigured -> NoAuth -> Ready.
         let _client = OpenRouterClient::<Unconfigured>::new()

--- a/src/utils/auth.rs
+++ b/src/utils/auth.rs
@@ -1,11 +1,16 @@
 //! Authentication utilities for managing API keys and authorization tokens.
 
 use crate::error::{Error, Result};
+use dotenv::dotenv;
 use std::env;
 
 /// Attempts to load an API key from environment variables.
 /// Checks for OPENROUTER_API_KEY and OR_API_KEY.
+/// Also loads from .env file if present.
 pub fn load_api_key_from_env() -> Result<String> {
+    // Load from .env file if present
+    dotenv().ok();
+
     // Try to read the API key from common environment variables
     if let Ok(key) = env::var("OPENROUTER_API_KEY") {
         if !key.trim().is_empty() {

--- a/src/utils/auth.rs
+++ b/src/utils/auth.rs
@@ -1,7 +1,7 @@
 //! Authentication utilities for managing API keys and authorization tokens.
 
 use crate::error::{Error, Result};
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 /// Attempts to load an API key from environment variables.


### PR DESCRIPTION
Hello, I hope that this small change will be helpful and worthwhile to merge. I store my OPENROUTER_API_KEY in my `.env` file, and so it was not being found by the `load_api_key_from_env` utility function. I added code to do so, which introduces a dependency on `dotenvy`. 

I am happy to make whatever changes are needed to merge this.