### PR TITLE
Use rustls instead of openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,11 @@ keywords = ["openrouter", "ai", "api-client"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.11", default_features = false, features = [
+  "json",
+  "rustls-tls",
+  "stream",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Using rustls makes the build simpler and more portable. This becomes important as I want to build this library in WASM.
