### PR TITLE
fix tool call streaming for openai models, introduce ToolCallChunk

### DIFF
--- a/src/models/tool.rs
+++ b/src/models/tool.rs
@@ -70,6 +70,35 @@ pub struct ToolCall {
     pub function_call: FunctionCall,
 }
 
+/// Represents a chunk of a function call as streamed from the API.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FunctionCallChunk {
+    /// The name of the function to call. Appears in the first chunk for a given function call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// A JSON string representing the arguments for the function call. Can be streamed in parts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<String>,
+}
+
+/// Represents a chunk of a tool call as streamed from the API.
+/// Fields are optional to accommodate partial data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallChunk {
+    /// The index of the tool call in the list of tool calls.
+    pub index: u32,
+    /// A unique identifier for the tool call. Appears in the first chunk for a given tool call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// The type of call. It must be "function" for function calls.
+    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// The details of the function call, including its function name and arguments.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<FunctionCallChunk>,
+}
+
 /// Represents a tool selection option when the model must choose among available tools.
 ///
 /// This enum covers three cases:

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -1,4 +1,4 @@
-use crate::models::tool::ToolCall;
+use crate::models::tool::{ToolCall, ToolCallChunk};
 use serde::{Deserialize, Serialize};
 
 /// Defines the role of a chat message (user, assistant, or system).
@@ -97,7 +97,7 @@ pub struct StreamDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool_calls: Option<Vec<ToolCall>>,
+    pub tool_calls: Option<Vec<ToolCallChunk>>,
 }
 
 /// A streaming chunk for chat completions.


### PR DESCRIPTION
When using openai models with streaming tool calls, the json deserializer didn't find a field. For google models it worked. It seems that models from google and openai send different fields in the stream. This PR introduces a new datastructure with optional fields to support both.
