### PR TITLE
Add FunctionDescription.strict

### DIFF
--- a/src/models/tool.rs
+++ b/src/models/tool.rs
@@ -27,6 +27,7 @@ pub struct FunctionDescription {
     /// A JSON Schema object representing the function parameters.
     /// This should be a valid JSON object describing the expected arguments.
     pub parameters: Value,
+    pub strict: Option<bool>,
 }
 
 /// Encapsulates a tool that the model can call.


### PR DESCRIPTION
This PR allows to use the function calling strict mode: <https://platform.openai.com/docs/guides/function-calling?api-mode=responses#defining-functions>
