### PR TITLE
ci: Remove macOS and Windows from test matrix to reduce build minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,10 @@ jobs:
 
   test-matrix:
     name: Test Matrix
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         rust: [stable, beta]
-        exclude:
-          # Reduce CI load by testing beta only on Ubuntu
-          - os: windows-latest
-            rust: beta
-          - os: macos-latest
-            rust: beta
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Remove macOS and Windows targets from CI test matrix
- Keep only Linux (ubuntu-latest) for testing as this library has no platform-specific dependencies
- Continue testing both stable and beta Rust versions
- Significantly reduces CI execution time and build minutes while maintaining adequate coverage

## Changes
- Simplified test matrix from 3 OS × 2 Rust versions to 1 OS × 2 Rust versions
- Removed complex exclude rules that are no longer needed
- Maintains comprehensive testing with stable and beta Rust on Linux

## Rationale
This is an API library with no platform-specific code, so Linux testing provides sufficient coverage for cross-platform compatibility. The removed targets were consuming unnecessary build minutes without providing additional value.