### PR TITLE
api: mark public response types/open enums #[non_exhaustive] (F2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 - **`bytes 1.11.0 → 1.11.1`** automatic via lockfile resolution after the above. Clears RUSTSEC-2026-0007.
 - Net: `cargo audit` reports 0 vulnerabilities, 0 unmaintained warnings.
 
+### ⚠️ SemVer-Relevant API Changes (Pre-1.0)
+- **`#[non_exhaustive]` applied to public response types and open enums.** This is a SemVer-minor change: downstream code that exhaustively matches these enums or uses struct-literal construction will need a catch-all arm or `..Default::default()`. The motivation is to allow future field/variant additions from the upstream OpenRouter API without forcing a major bump every time. Affected types:
+  - **Response structs:** `Choice`, `LogProbs`, `TokenLogProb`, `TopLogProb`, `ServerToolUse`, `Usage`, `PromptTokensDetails`, `CompletionTokensDetails`, `ChatCompletionResponse`, `ChoiceStream`, `StreamDelta`, `ChatCompletionChunk`, `EmbeddingData`, `EmbeddingUsage`, `EmbeddingResponse`, `ActivityData`, `ActivityResponse`, `ModelUsageStats`, `ProviderUsageStats`, `FeatureUsagePercentages`, `CreditsData`, `CreditsResponse`, `GenerationData`, `GenerationResponse`, `Guardrail`, `GuardrailResponse`, `GuardrailsListResponse`, `GuardrailKeyAssignment`, `GuardrailMemberAssignment`, `GuardrailKeyAssignmentsResponse`, `GuardrailMemberAssignmentsResponse`, `BulkAssignResponse`, `BulkUnassignResponse`, `GuardrailDeleteResponse`, `ApiErrorDetails`.
+  - **Open-ended enums:** `ContentType`, `ChatRole`, `RouteStrategy`, `ImageDetail`, `VerbosityLevel`, `ReasoningEffort`, `ReasoningSummary`, `SortOrder`, `SortField`, `GuardrailResetInterval`, `DataCollection`, `ProviderSort`, `Quantization`.
+  - User-construction structs (`Message`, `ChatCompletionRequest`, the multimodal `Content` parts, `Plugin`, `Tool`, etc.) and content-variant enums users typically pattern-match (`ContentPart`, `MessageContent`, `ReasoningDetail`, `Tool`, `ToolType`, `ToolChoice`) are intentionally NOT marked `#[non_exhaustive]` to preserve struct-literal construction.
+
 ---
 
 ## [0.5.1] - 2025-12-27

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use crate::utils::security::create_safe_error_message;
 
 /// OpenRouter API error details
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ApiErrorDetails {
     /// Error code (e.g., "insufficient_quota")
     pub code: Option<String>,

--- a/src/models/provider_preferences.rs
+++ b/src/models/provider_preferences.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Defines the data collection policy when selecting providers.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum DataCollection {
     Allow,
     Deny,
@@ -18,6 +19,7 @@ pub enum DataCollection {
 /// Defines provider sort preferences.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ProviderSort {
     Price,
     Throughput,
@@ -26,6 +28,7 @@ pub enum ProviderSort {
 /// Defines quantization filtering options.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Quantization {
     Int4,
     Int8,

--- a/src/types/analytics.rs
+++ b/src/types/analytics.rs
@@ -28,6 +28,7 @@ pub mod constants {
 
 /// Sort order for activity queries
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SortOrder {
     Ascending,
     Descending,
@@ -44,6 +45,7 @@ impl SortOrder {
 
 /// Sort field for activity queries
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SortField {
     CreatedAt,
     Cost,
@@ -64,6 +66,7 @@ impl SortField {
 
 /// Activity data for a specific request
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct ActivityData {
     /// Unique identifier for the request
     pub id: ActivityId,
@@ -284,6 +287,7 @@ impl ActivityRequest {
 
 /// Response from the activity endpoint
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct ActivityResponse {
     /// List of activity data entries
     pub data: Vec<ActivityData>,
@@ -496,6 +500,7 @@ impl ActivityResponse {
 
 /// Usage statistics for a specific model
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ModelUsageStats {
     pub model: String,
     pub request_count: usize,
@@ -507,6 +512,7 @@ pub struct ModelUsageStats {
 
 /// Usage statistics for a specific provider
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ProviderUsageStats {
     pub provider: String,
     pub request_count: usize,
@@ -518,6 +524,7 @@ pub struct ProviderUsageStats {
 
 /// Feature usage percentages
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct FeatureUsagePercentages {
     pub web_search: f64,
     pub media: f64,

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 /// invalid content types unrepresentable at compile time.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ContentType {
     /// Plain text content.
     Text,
@@ -38,6 +39,7 @@ impl std::fmt::Display for ContentType {
 /// Defines the role of a chat message (user, assistant, or system).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ChatRole {
     User,
     Assistant,
@@ -75,6 +77,7 @@ pub struct PredictionConfig {
 /// Verbosity level for model responses.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum VerbosityLevel {
     Low,
     Medium,
@@ -84,6 +87,7 @@ pub enum VerbosityLevel {
 /// Route strategy for model routing.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum RouteStrategy {
     Fallback,
 }
@@ -91,6 +95,7 @@ pub enum RouteStrategy {
 /// Image detail level for vision models.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ImageDetail {
     Auto,
     Low,
@@ -436,6 +441,7 @@ impl Plugin {
 /// Effort level for reasoning models (o1, o3, Claude extended thinking, DeepSeek R1).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ReasoningEffort {
     XHigh,
     High,
@@ -448,6 +454,7 @@ pub enum ReasoningEffort {
 /// Summary verbosity for reasoning models that expose summarized thinking output.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ReasoningSummary {
     Auto,
     Concise,
@@ -643,6 +650,7 @@ pub struct ChatCompletionRequest {
 
 /// A choice returned by the chat API.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct Choice {
     pub message: Message,
     pub finish_reason: Option<String>,
@@ -654,12 +662,14 @@ pub struct Choice {
 
 /// Log probabilities information.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct LogProbs {
     pub content: Option<Vec<TokenLogProb>>,
 }
 
 /// Token log probability information.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct TokenLogProb {
     pub token: String,
     pub logprob: f32,
@@ -669,6 +679,7 @@ pub struct TokenLogProb {
 
 /// Top log probability information.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct TopLogProb {
     pub token: String,
     pub logprob: f32,
@@ -677,6 +688,7 @@ pub struct TopLogProb {
 
 /// Server-side tool usage counts (e.g., web search requests).
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ServerToolUse {
     /// Number of web search requests made by the server.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -688,6 +700,7 @@ pub struct ServerToolUse {
 
 /// Usage data returned from the API.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
@@ -704,6 +717,7 @@ pub struct Usage {
 
 /// Details about prompt token usage.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct PromptTokensDetails {
     pub cached_tokens: Option<u32>,
     pub audio_tokens: Option<u32>,
@@ -717,6 +731,7 @@ pub struct PromptTokensDetails {
 
 /// Details about completion token usage.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct CompletionTokensDetails {
     pub reasoning_tokens: Option<u32>,
     pub audio_tokens: Option<u32>,
@@ -726,6 +741,7 @@ pub struct CompletionTokensDetails {
 
 /// Chat completion response.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct ChatCompletionResponse {
     pub id: String,
     pub choices: Vec<Choice>,
@@ -740,6 +756,7 @@ pub struct ChatCompletionResponse {
 /// A choice returned by the streaming chat API.
 /// Different from regular Choice as it contains deltas instead of complete messages.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct ChoiceStream {
     pub index: u32,
     pub delta: StreamDelta,
@@ -751,6 +768,7 @@ pub struct ChoiceStream {
 
 /// Delta content for streaming responses.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct StreamDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
@@ -768,6 +786,7 @@ pub struct StreamDelta {
 
 /// A streaming chunk for chat completions.
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 pub struct ChatCompletionChunk {
     pub id: String,
     pub object: String,

--- a/src/types/credits.rs
+++ b/src/types/credits.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Credits data returned by the OpenRouter API.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct CreditsData {
     /// Total credits purchased by the user
     pub total_credits: f64,
@@ -37,6 +38,7 @@ impl CreditsData {
 
 /// Response from the credits endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct CreditsResponse {
     /// Credits data
     pub data: CreditsData,

--- a/src/types/embeddings.rs
+++ b/src/types/embeddings.rs
@@ -37,6 +37,7 @@ pub struct EmbeddingRequest {
 
 /// A single embedding result.
 #[derive(Debug, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct EmbeddingData {
     /// The embedding vector.
     pub embedding: Vec<f64>,
@@ -49,6 +50,7 @@ pub struct EmbeddingData {
 
 /// Usage information for an embedding request.
 #[derive(Debug, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct EmbeddingUsage {
     /// Number of tokens in the input.
     pub prompt_tokens: u32,
@@ -58,6 +60,7 @@ pub struct EmbeddingUsage {
 
 /// Response from `POST /api/v1/embeddings`.
 #[derive(Debug, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct EmbeddingResponse {
     /// Object type — "list".
     pub object: String,

--- a/src/types/generation.rs
+++ b/src/types/generation.rs
@@ -7,6 +7,7 @@ use crate::types::status::{CancellationStatus, StreamingStatus};
 
 /// Generation data returned by the OpenRouter API.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct GenerationData {
     /// Unique identifier for the generation
     pub id: GenerationId,
@@ -142,6 +143,7 @@ impl GenerationData {
 
 /// Response from the generation endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct GenerationResponse {
     /// Generation data
     pub data: GenerationData,

--- a/src/types/guardrails.rs
+++ b/src/types/guardrails.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Interval at which a guardrail spending limit resets.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum GuardrailResetInterval {
     Daily,
     Weekly,
@@ -13,6 +14,7 @@ pub enum GuardrailResetInterval {
 
 /// A configured guardrail.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct Guardrail {
     /// Unique identifier for the guardrail.
     pub id: String,
@@ -48,6 +50,7 @@ pub struct Guardrail {
 
 /// Response wrapper for a single guardrail.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct GuardrailResponse {
     /// Guardrail payload.
     pub data: Guardrail,
@@ -55,6 +58,7 @@ pub struct GuardrailResponse {
 
 /// Response wrapper for a list of guardrails.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct GuardrailsListResponse {
     /// Guardrails in the current page.
     pub data: Vec<Guardrail>,
@@ -272,6 +276,7 @@ impl GuardrailUpdateRequest {
 
 /// API key assignment entry for a guardrail.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct GuardrailKeyAssignment {
     /// Unique assignment ID.
     pub id: String,
@@ -292,6 +297,7 @@ pub struct GuardrailKeyAssignment {
 
 /// Organization member assignment entry for a guardrail.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct GuardrailMemberAssignment {
     /// Unique assignment ID.
     pub id: String,
@@ -310,6 +316,7 @@ pub struct GuardrailMemberAssignment {
 
 /// Response wrapper for guardrail key assignments.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct GuardrailKeyAssignmentsResponse {
     /// Assignment page data.
     pub data: Vec<GuardrailKeyAssignment>,
@@ -319,6 +326,7 @@ pub struct GuardrailKeyAssignmentsResponse {
 
 /// Response wrapper for guardrail member assignments.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct GuardrailMemberAssignmentsResponse {
     /// Assignment page data.
     pub data: Vec<GuardrailMemberAssignment>,
@@ -358,6 +366,7 @@ impl BulkAssignMembersRequest {
 
 /// Response for successful bulk assignment operations.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct BulkAssignResponse {
     /// Number of entities assigned.
     pub assigned_count: u32,
@@ -365,6 +374,7 @@ pub struct BulkAssignResponse {
 
 /// Response for successful bulk unassignment operations.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct BulkUnassignResponse {
     /// Number of entities unassigned.
     pub unassigned_count: u32,
@@ -372,6 +382,7 @@ pub struct BulkUnassignResponse {
 
 /// Response for guardrail deletion.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct GuardrailDeleteResponse {
     /// Whether the guardrail was deleted.
     pub deleted: bool,

--- a/tests/message_consolidation.rs
+++ b/tests/message_consolidation.rs
@@ -21,12 +21,14 @@ use serde_json::{from_str, from_value, to_value};
 fn test_message_uses_chat_role_enum() {
     let msg = Message::text(ChatRole::User, "Hello, world!");
 
-    // This should compile - role is ChatRole, not String
+    // This should compile - role is ChatRole, not String. ChatRole is
+    // `#[non_exhaustive]`, so integration-test matches need a wildcard arm.
     match msg.role {
         ChatRole::User => {} // ✅ Should match
         ChatRole::Assistant => panic!("Wrong role"),
         ChatRole::System => panic!("Wrong role"),
         ChatRole::Tool => panic!("Wrong role"),
+        _ => panic!("Unknown role"),
     }
 }
 

--- a/tests/type_safety/enum_non_exhaustive_match.stderr
+++ b/tests/type_safety/enum_non_exhaustive_match.stderr
@@ -1,22 +1,18 @@
-error[E0004]: non-exhaustive patterns: `ChatRole::System` and `ChatRole::Tool` not covered
+error[E0004]: non-exhaustive patterns: `_` not covered
   --> tests/type_safety/enum_non_exhaustive_match.rs:11:11
    |
 11 |     match role {
-   |           ^^^^ patterns `ChatRole::System` and `ChatRole::Tool` not covered
+   |           ^^^^ pattern `_` not covered
    |
 note: `ChatRole` defined here
   --> src/types/chat.rs
    |
    | pub enum ChatRole {
    | ^^^^^^^^^^^^^^^^^
-...
-   |     System,
-   |     ------ not covered
-   |     Tool,
-   |     ---- not covered
    = note: the matched value is of type `ChatRole`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+   = note: `ChatRole` is marked as non-exhaustive, so a wildcard `_` is necessary to match exhaustively
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 13 ~         ChatRole::Assistant => "assistant response",
-14 ~         ChatRole::System | ChatRole::Tool => todo!(),
+14 ~         _ => todo!(),
    |

--- a/tests/type_safety/pattern_non_exhaustive.stderr
+++ b/tests/type_safety/pattern_non_exhaustive.stderr
@@ -6,25 +6,21 @@ warning: unused import: `StreamingStatus`
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
 
-error[E0004]: non-exhaustive patterns: `ChatRole::System` and `ChatRole::Tool` not covered
+error[E0004]: non-exhaustive patterns: `_` not covered
   --> tests/type_safety/pattern_non_exhaustive.rs:14:11
    |
 14 |     match role {
-   |           ^^^^ patterns `ChatRole::System` and `ChatRole::Tool` not covered
+   |           ^^^^ pattern `_` not covered
    |
 note: `ChatRole` defined here
   --> src/types/chat.rs
    |
    | pub enum ChatRole {
    | ^^^^^^^^^^^^^^^^^
-...
-   |     System,
-   |     ------ not covered
-   |     Tool,
-   |     ---- not covered
    = note: the matched value is of type `ChatRole`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+   = note: `ChatRole` is marked as non-exhaustive, so a wildcard `_` is necessary to match exhaustively
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 16 ~         ChatRole::Assistant => "assistant response",
-17 ~         ChatRole::System | ChatRole::Tool => todo!(),
+17 ~         _ => todo!(),
    |


### PR DESCRIPTION
## Finding

**F2.8 — \`#[non_exhaustive]\` is not used on any of ~100 public types** (severity: P1).

From \`MAINTENANCE_REPORT_2026-05.md\`:

> For a client wrapping a fast-evolving upstream API (OpenRouter ships new fields/plugins every few weeks), every new field on a public response struct or new variant on a public enum is a SemVer-breaking change. The \`[Unreleased]\` CHANGELOG entry alone added \`cache_creation_input_tokens\`, \`cache_read_input_tokens\`, \`cache_discount\`, \`provider_name\`, and four reasoning-related types — each technically a major bump under strict SemVer.
>
> Recommended action: As a one-time pass, mark response/notification structs (Usage, ChatCompletionResponse, ProviderInfo, ModelInfo, etc.) and the open-ended Plugin/ContentType/ChatRole enums \`#[non_exhaustive]\`. Do this *before* a 1.0 release; doing it after is itself a breaking change.

## Diff summary

54 lines added (one \`#[non_exhaustive]\` line per type) across 9 files:

- **Response structs** (server-driven; users receive these): \`Choice\`, \`LogProbs\`, \`TokenLogProb\`, \`TopLogProb\`, \`ServerToolUse\`, \`Usage\`, \`PromptTokensDetails\`, \`CompletionTokensDetails\`, \`ChatCompletionResponse\`, \`ChoiceStream\`, \`StreamDelta\`, \`ChatCompletionChunk\`, \`EmbeddingData\`, \`EmbeddingUsage\`, \`EmbeddingResponse\`, \`ActivityData\`, \`ActivityResponse\`, \`ModelUsageStats\`, \`ProviderUsageStats\`, \`FeatureUsagePercentages\`, \`CreditsData\`, \`CreditsResponse\`, \`GenerationData\`, \`GenerationResponse\`, the eleven \`Guardrail*\`/\`Bulk*\` response types, and \`ApiErrorDetails\`.
- **Open-ended enums** (provider may add variants): \`ContentType\`, \`ChatRole\`, \`RouteStrategy\`, \`ImageDetail\`, \`VerbosityLevel\`, \`ReasoningEffort\`, \`ReasoningSummary\`, \`SortOrder\`, \`SortField\`, \`GuardrailResetInterval\`, \`DataCollection\`, \`ProviderSort\`, \`Quantization\`.
- CHANGELOG \`[Unreleased]\` records the change in detail.

## Intentionally NOT marked

Request structs (\`Message\`, \`ChatCompletionRequest\`, \`EmbeddingRequest\`, request bodies for guardrails, \`Plugin\`, \`PredictionConfig\`, \`ReasoningConfig\`, etc.) and content-variant enums users pattern-match (\`ContentPart\`, \`MessageContent\`, \`ReasoningDetail\`, \`Tool\`, \`ToolType\`, \`ToolChoice\`, \`StopSequence\`) — these are construction surfaces or routinely-matched enums where \`#[non_exhaustive]\` would just force \`..Default::default()\` everywhere or break common matches without proportional benefit.

## SemVer impact

Pre-1.0 (current 0.5.1). Per the maintainer's stated SemVer flexibility, breaking changes are documented in CHANGELOG and acceptable when justified. This change is documented under \`[Unreleased]\` → \"SemVer-Relevant API Changes (Pre-1.0)\".

Downstream users will need:
- A \`_ =>\` arm when exhaustively matching the marked enums.
- \`..Default::default()\` (or constructor methods, where available) when struct-literal-constructing the marked response types.

## Before / After

\`\`\`
\$ grep -rln \"#\\[non_exhaustive\\]\" src/   # before — empty
\`\`\`

\`\`\`
\$ grep -rl \"#\\[non_exhaustive\\]\" src/ | wc -l   # after
9   # files: chat, embeddings, analytics, credits, generation, guardrails,
    #        error, models/provider_preferences (counted from src/, plus
    #        src/types/embeddings.rs)
\`\`\`

\`\`\`
\$ cargo test --features tls-rustls,tracing,allow-http --lib
test result: ok. 388 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
\`\`\`

(\`fmt --check\` clean. Pre-existing F2.1 / F3.2 CI inheritance applies.)