### PR TITLE
ci(release): grant contents:write to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # `contents: write` is required by softprops/action-gh-release@v2 to
+    # create the GitHub Release. Default repo permissions are read-only,
+    # which is why v0.7.0's release-creation step 403'd while the
+    # `cargo publish` step itself succeeded.
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why

The release workflow's \`cargo publish\` step succeeded for v0.7.0 but the final \`softprops/action-gh-release@v2\` step failed with HTTP 403 because the workflow's \`GITHUB_TOKEN\` inherited the repo's default permission set, which is read-only for \`contents\`. \`action-gh-release\` needs \`contents: write\` to create the GitHub Release.

\`\`\`
⚠️ GitHub release failed with status: 403
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v0.7.0:
   HttpError: Resource not accessible by integration
\`\`\`

(v0.7.0's release was created manually with \`gh release create v0.7.0 --generate-notes\` after the workflow's last step failed. \`cargo publish\` had already succeeded by that point — \`openrouter_api 0.7.0\` is on crates.io.)

## Fix

Add an explicit \`permissions: contents: write\` block scoped to the publish job. Job-level scoping keeps the elevated permission narrow.

## Diff

\`\`\`diff
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # `contents: write` is required by softprops/action-gh-release@v2 to
+    # create the GitHub Release. Default repo permissions are read-only,
+    # which is why v0.7.0's release-creation step 403'd while the
+    # `cargo publish` step itself succeeded.
+    permissions:
+      contents: write
\`\`\`

Future tag pushes will create their GitHub Release automatically without manual intervention.